### PR TITLE
Since 2025-09-29 Qwen closed unversioned endpoints, and we need v2 paths

### DIFF
--- a/qwen_api/qwen_api/core/types/endpoint_api.py
+++ b/qwen_api/qwen_api/core/types/endpoint_api.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class EndpointAPI:
     new_chat: str = "/api/v1/chats/new"
-    completions: str = "/api/chat/completions"
-    completed: str = "/api/chat/completed"
-    suggestions: str = "/api/task/suggestions/completions"
+    completions: str = "/api/v2/chat/completions"
+    completed: str = "/api/v2/chat/completed"
+    suggestions: str = "/api/v2/task/suggestions/completions"
     upload_file: str = "/api/v1/files/getstsToken"


### PR DESCRIPTION
Since 2025-09-29 Qwen close unversioned endpoints, and we need v2 paths according to chats